### PR TITLE
hard wrap 옵션 적용

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -190,7 +190,7 @@ incremental: false
 # Markdown Processing
 kramdown:
   input: GFM
-  hard_wrap: false
+  hard_wrap: true
   auto_ids: true
   footnote_nr: 1
   entity_output: as_char


### PR DESCRIPTION
line break 적용되지 않는 이슈 수정

https://stackoverflow.com/questions/52762454/jekyll-markdown-with-line-feed-is-not-rendered-in-html/62732579#62732579